### PR TITLE
Inventory licensezero.json files (close #4)

### DIFF
--- a/inventory/generic.go
+++ b/inventory/generic.go
@@ -68,6 +68,7 @@ func ReadLicenseZeroFiles(directoryPath string) ([]Project, error) {
 
 func findPackageInfo(directoryPath string) *Project {
 	approaches := []func(string) *Project{
+		findNPMPackageInfo,
 		findPythonPackageInfo,
 		findMavenPackageInfo,
 	}

--- a/inventory/generic.go
+++ b/inventory/generic.go
@@ -1,0 +1,119 @@
+package inventory
+
+import "bytes"
+import "encoding/json"
+import "github.com/yookoala/realpath"
+import "io/ioutil"
+import "os"
+import "os/exec"
+import "path"
+import "strings"
+
+type LicenseZeroJSONFile struct {
+	Version   string                    `json:"version"`
+	Envelopes []ProjectManifestEnvelope `json:"licensezero"`
+}
+
+// TODO: Consider reading setup.py --url and checking against homepage for Python.
+
+func ReadLicenseZeroFiles(directoryPath string) ([]Project, error) {
+	var returned []Project
+	entries, err := readAndStatDir(directoryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Project{}, nil
+		} else {
+			return nil, err
+		}
+	}
+	processProject := func(directory string) error {
+		json_file := path.Join(directory, "licensezero.json")
+		data, err := ioutil.ReadFile(json_file)
+		if err != nil {
+			return err
+		}
+		var parsed LicenseZeroJSONFile
+		json.Unmarshal(data, &parsed)
+		anyNewProjects := false
+		for _, envelope := range parsed.Envelopes {
+			if alreadyHaveProject(returned, envelope.Manifest.ProjectID) {
+				continue
+			}
+			anyNewProjects = true
+			project := Project{
+				Path:     directory,
+				Envelope: envelope,
+			}
+			realDirectory, err := realpath.Realpath(directory)
+			if err != nil {
+				project.Path = realDirectory
+			} else {
+				project.Path = directory
+			}
+			packageInfo := findPackageInfo(directory)
+			if packageInfo != nil {
+				project.Type = packageInfo.Type
+				project.Name = packageInfo.Name
+				project.Version = packageInfo.Version
+			}
+			returned = append(returned, project)
+		}
+		if anyNewProjects {
+			below, recursionError := ReadNPMProjects(directory)
+			if recursionError != nil {
+				return recursionError
+			}
+			returned = append(returned, below...)
+		}
+		return nil
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		directory := path.Join(directoryPath, name)
+		err := processProject(directory)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return returned, nil
+}
+
+func findPackageInfo(directoryPath string) *Project {
+	approaches := []func(string) *Project{
+		findPythonPackageInfo,
+	}
+	for _, approach := range approaches {
+		returned := approach(directoryPath)
+		if returned != nil {
+			return returned
+		}
+	}
+	return nil
+}
+
+func findPythonPackageInfo(directoryPath string) *Project {
+	setup := path.Join(directoryPath, "setup.py")
+	_, err := os.Stat(setup)
+	if err != nil {
+		return nil
+	}
+	command := exec.Command("python", "setup.py", "--name", "--version")
+	var stdout bytes.Buffer
+	command.Stdout = &stdout
+	err = command.Run()
+	if err != nil {
+		return nil
+	}
+	output := string(stdout.Bytes())
+	lines := strings.Split(output, "\n")
+	name := strings.TrimSpace(lines[0])
+	version := strings.TrimSpace(lines[1])
+	return &Project{
+		Type:    "python",
+		Name:    name,
+		Version: version,
+	}
+}

--- a/inventory/generic.go
+++ b/inventory/generic.go
@@ -55,6 +55,7 @@ func ReadLicenseZeroFiles(directoryPath string) ([]Project, error) {
 				project.Type = packageInfo.Type
 				project.Name = packageInfo.Name
 				project.Version = packageInfo.Version
+				project.Scope = packageInfo.Scope
 			}
 			returned = append(returned, project)
 		}
@@ -84,6 +85,7 @@ func ReadLicenseZeroFiles(directoryPath string) ([]Project, error) {
 func findPackageInfo(directoryPath string) *Project {
 	approaches := []func(string) *Project{
 		findPythonPackageInfo,
+		findMavenPackageInfo,
 	}
 	for _, approach := range approaches {
 		returned := approach(directoryPath)

--- a/inventory/generic.go
+++ b/inventory/generic.go
@@ -11,8 +11,6 @@ type LicenseZeroJSONFile struct {
 	Envelopes []ProjectManifestEnvelope `json:"licensezero"`
 }
 
-// TODO: Consider reading setup.py --url and checking against homepage for Python.
-
 func ReadLicenseZeroFiles(directoryPath string) ([]Project, error) {
 	var returned []Project
 	entries, err := readAndStatDir(directoryPath)

--- a/inventory/generic.go
+++ b/inventory/generic.go
@@ -1,13 +1,10 @@
 package inventory
 
-import "bytes"
 import "encoding/json"
 import "github.com/yookoala/realpath"
 import "io/ioutil"
 import "os"
-import "os/exec"
 import "path"
-import "strings"
 
 type LicenseZeroJSONFile struct {
 	Version   string                    `json:"version"`
@@ -94,28 +91,4 @@ func findPackageInfo(directoryPath string) *Project {
 		}
 	}
 	return nil
-}
-
-func findPythonPackageInfo(directoryPath string) *Project {
-	setup := path.Join(directoryPath, "setup.py")
-	_, err := os.Stat(setup)
-	if err != nil {
-		return nil
-	}
-	command := exec.Command("python", "setup.py", "--name", "--version")
-	var stdout bytes.Buffer
-	command.Stdout = &stdout
-	err = command.Run()
-	if err != nil {
-		return nil
-	}
-	output := string(stdout.Bytes())
-	lines := strings.Split(output, "\n")
-	name := strings.TrimSpace(lines[0])
-	version := strings.TrimSpace(lines[1])
-	return &Project{
-		Type:    "python",
-		Name:    name,
-		Version: version,
-	}
 }

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -131,7 +131,18 @@ func OwnProject(project *Project, identity *data.Identity) bool {
 }
 
 func ReadProjects(cwd string) ([]Project, error) {
-	return ReadNPMProjects(cwd)
+	descenders := []func(string) ([]Project, error){
+		ReadNPMProjects,
+		ReadLicenseZeroFiles,
+	}
+	returned := []Project{}
+	for _, descender := range descenders {
+		projects, err := descender(cwd)
+		if err == nil {
+			returned = append(returned, projects...)
+		}
+	}
+	return returned, nil
 }
 
 func isSymlink(entry os.FileInfo) bool {

--- a/inventory/maven.go
+++ b/inventory/maven.go
@@ -1,0 +1,33 @@
+package inventory
+
+import "encoding/xml"
+import "io/ioutil"
+import "path"
+
+type POM struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	Version    string `xml:"version"`
+}
+
+func findMavenPackageInfo(directoryPath string) *Project {
+	pom_xml := path.Join(directoryPath, "pom.xml")
+	data, err := ioutil.ReadFile(pom_xml)
+	if err != nil {
+		return nil
+	}
+	var parsed POM
+	xml.Unmarshal(data, &parsed)
+	if err != nil {
+		return nil
+	}
+	if parsed.ArtifactID == "" {
+		return nil
+	}
+	return &Project{
+		Type:    "maven",
+		Name:    parsed.ArtifactID,
+		Scope:   parsed.GroupID,
+		Version: parsed.Version,
+	}
+}

--- a/inventory/npm.go
+++ b/inventory/npm.go
@@ -112,3 +112,35 @@ func alreadyHaveProject(projects []Project, projectID string) bool {
 }
 
 // TODO: Move package.json writing function into inventory.
+
+func findNPMPackageInfo(directoryPath string) *Project {
+	package_json := path.Join(directoryPath, "package.json")
+	data, err := ioutil.ReadFile(package_json)
+	if err != nil {
+		return nil
+	}
+	var parsed struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	json.Unmarshal(data, &parsed)
+	if err != nil {
+		return nil
+	}
+	rawName := parsed.Name
+	var name, scope string
+	// If the name looks like @scope/name, parse it.
+	if strings.HasPrefix(rawName, "@") && strings.Index(rawName, "/") != -1 {
+		index := strings.Index(rawName, "/")
+		scope = rawName[1 : index-1]
+		name = rawName[index:]
+	} else {
+		name = rawName
+	}
+	return &Project{
+		Type:    "npm",
+		Name:    name,
+		Scope:   scope,
+		Version: parsed.Version,
+	}
+}

--- a/inventory/python.go
+++ b/inventory/python.go
@@ -1,0 +1,31 @@
+package inventory
+
+import "bytes"
+import "os"
+import "os/exec"
+import "path"
+import "strings"
+
+func findPythonPackageInfo(directoryPath string) *Project {
+	setup := path.Join(directoryPath, "setup.py")
+	_, err := os.Stat(setup)
+	if err != nil {
+		return nil
+	}
+	command := exec.Command("python", "setup.py", "--name", "--version")
+	var stdout bytes.Buffer
+	command.Stdout = &stdout
+	err = command.Run()
+	if err != nil {
+		return nil
+	}
+	output := string(stdout.Bytes())
+	lines := strings.Split(output, "\n")
+	name := strings.TrimSpace(lines[0])
+	version := strings.TrimSpace(lines[1])
+	return &Project{
+		Type:    "python",
+		Name:    name,
+		Version: version,
+	}
+}

--- a/subcommands/license.go
+++ b/subcommands/license.go
@@ -74,6 +74,18 @@ var License = Subcommand{
 			entries := existingMetadata.LicenseZero
 			if len(existingMetadata.LicenseZero) != 0 {
 				if *stack {
+					// Check if project already listed.
+					for _, entry := range entries {
+						if itemsMap, ok := entry.(map[string]interface{}); ok {
+							if license, ok := itemsMap["license"].(map[string]interface{}); ok {
+								if otherID, ok := license["projectID"].(string); ok {
+									if otherID == *projectID {
+										Fail("Project ID " + *projectID + " already appears in licensezero.json.")
+									}
+								}
+							}
+						}
+					}
 					entries = append(existingMetadata.LicenseZero, newEntry)
 				} else {
 					Fail("licensezero.json already has License Zero metadata.\nUse --stack to stack metadata.")

--- a/subcommands/license.go
+++ b/subcommands/license.go
@@ -103,6 +103,16 @@ var License = Subcommand{
 			os.Stdout.WriteString("Appended terms to LICENSE.\n")
 		}
 		// TODO: Write licensezero.json to package.json files, MANIFEST.in, and similar.
+		if !*silent {
+			os.Stdout.WriteString(
+				"" +
+					"Make sure to configure your package manager to include licensezero.json\n" +
+					"in your package distribution.\n\n" +
+					"npm:    Add licensezero.json to the files array of your npm package's\n" +
+					"        package.json file, if you have one.\n\n" +
+					"Python: Add licensezero.json to MANIFEST.in.\n",
+			)
+		}
 		os.Exit(0)
 	},
 }

--- a/subcommands/quote.go
+++ b/subcommands/quote.go
@@ -89,6 +89,23 @@ var Quote = Subcommand{
 			if project.Retracted {
 				fmt.Println("  Retracted!")
 			}
+			if prior != nil {
+				if prior.Type != "" {
+					fmt.Println("  Type: " + prior.Type)
+				}
+				if prior.Path != "" {
+					fmt.Println("  Path: " + prior.Path)
+				}
+				if prior.Scope != "" {
+					fmt.Println("  Scope: " + prior.Scope)
+				}
+				if prior.Name != "" {
+					fmt.Println("  Name: " + prior.Name)
+				}
+				if prior.Version != "" {
+					fmt.Println("  Version: " + prior.Version)
+				}
+			}
 			fmt.Println("  Price: " + currency(project.Pricing.Private))
 			fmt.Printf("\nTotal: %s\n", currency(total))
 		}

--- a/subcommands/quote.go
+++ b/subcommands/quote.go
@@ -50,6 +50,9 @@ var Quote = Subcommand{
 		fmt.Printf("Ignored: %d\n", len(ignored))
 		fmt.Printf("Unlicensed: %d\n", len(unlicensed))
 		fmt.Printf("Invalid: %d\n", len(invalid))
+		if len(unlicensed) == 0 {
+			os.Exit(0)
+		}
 		var projectIDs []string
 		for _, project := range unlicensed {
 			projectIDs = append(projectIDs, project.Envelope.Manifest.ProjectID)

--- a/subcommands/quote.go
+++ b/subcommands/quote.go
@@ -63,18 +63,26 @@ var Quote = Subcommand{
 		}
 		var total uint
 		for _, project := range response.Projects {
+			var prior *inventory.Project
+			for _, candidate := range unlicensed {
+				if candidate.Envelope.Manifest.ProjectID == project.ProjectID {
+					prior = &candidate
+					break
+				}
+			}
 			total += project.Pricing.Private
 			fmt.Println("\n- Project: " + project.ProjectID)
 			fmt.Println("  Description: " + project.Description)
 			fmt.Println("  Repository: " + project.Repository)
-			for _, prior := range unlicensed {
-				if prior.Envelope.Manifest.ProjectID == project.ProjectID {
-					if prior.Envelope.Manifest.Terms == "noncommercial" {
-						fmt.Println("  Terms: Noncommercial " + prior.Version)
-					} else if prior.Envelope.Manifest.Terms == "reciprocal" {
-						fmt.Println("  Terms: Reciprocal " + prior.Version)
-					}
-					break
+			if prior != nil {
+				if prior.Envelope.Manifest.Terms == "noncommercial" {
+					fmt.Println("  Terms: Noncommercial")
+				} else if prior.Envelope.Manifest.Terms == "reciprocal" {
+					fmt.Println("  Terms: Reciprocal")
+				} else if prior.Envelope.Manifest.Terms == "parity" {
+					fmt.Println("  Terms: Parity")
+				} else if prior.Envelope.Manifest.Terms == "prosperity" {
+					fmt.Println("  Terms: Prosperity")
 				}
 			}
 			fmt.Println("  Licensor: " + project.Licensor.Name + " [" + project.Licensor.Jurisdiction + "]")

--- a/subcommands/relicense.go
+++ b/subcommands/relicense.go
@@ -34,21 +34,21 @@ var Relicense = Subcommand{
 		if err != nil {
 			Fail("Error sending license information request.")
 		}
-		// Add metadata to package.json.
-		package_json := path.Join(paths.CWD, "package.json")
-		data, err := ioutil.ReadFile(package_json)
+		// Add metadata to licensezero.json.
+		licnsezero_json := path.Join(paths.CWD, "licensezero.json")
+		data, err := ioutil.ReadFile(licnsezero_json)
 		if err != nil {
-			Fail("Could not read package.json.")
+			Fail("Could not read licensezero.json.")
 		}
 		var existingJSON interface{}
 		var existingMetadata inventory.PackageJSONFile
 		err = json.Unmarshal(data, &existingJSON)
 		if err != nil {
-			Fail("Error parsing package.json.")
+			Fail("Error parsing licensezero.json.")
 		}
 		err = json.Unmarshal(data, &existingMetadata)
 		if err != nil {
-			Fail("Error parsing package.json.")
+			Fail("Error parsing licensezero.json.")
 		}
 		newEntries := []inventory.ProjectManifestEnvelope{}
 		for _, entry := range existingMetadata.Envelopes {
@@ -66,9 +66,9 @@ var Relicense = Subcommand{
 		if err != nil {
 			Fail("Error serializing new JSON.")
 		}
-		err = ioutil.WriteFile(package_json, serialized.Bytes(), 0644)
+		err = ioutil.WriteFile(licnsezero_json, serialized.Bytes(), 0644)
 		if !*silent {
-			os.Stdout.WriteString("Added metadata to package.json.\n")
+			os.Stdout.WriteString("Added metadata to licensezero.json.\n")
 		}
 		// Overwrite LICENSE.
 		err = overwriteLICENSE(&response)

--- a/subcommands/reprice.go
+++ b/subcommands/reprice.go
@@ -38,10 +38,10 @@ var Reprice = Subcommand{
 		} else {
 			projectIDs, _, err := readEntries(paths.CWD)
 			if err != nil {
-				Fail("Could not read package.json.")
+				Fail("Could not read licensezero.json.")
 			}
 			if len(projectIDs) > 0 {
-				os.Stderr.WriteString("package.json has metadata for multiple License Zero projects.\n")
+				os.Stderr.WriteString("licensezero.json has metadata for multiple License Zero projects.\n")
 				Fail("Use --project to specify your project ID.")
 			}
 		}


### PR DESCRIPTION
This PR tries to address #1 and #3 by closing #4.

The basic approach is:

1. Recurse every directory of the project.
2. If you see a `licensezero.json`, parse it just like the `licensezero` property of a `package.json` file.
3. Look in the same directory.
4. If there's a `setup.py`, run `python setup.py --name --version`.
5. If there's a `pom.xml`, parse the XML for `groupId`, `artifactId`, and `version`.

There is some thinking to be done about how to whether and how to link `licensezero.json` files to packages, or more likely package metadata. We could require `licensezero.json` files to include signed data linking the two in some sense. But I'm not sure it's worth trying to enforce links between packages and license metadata technically.