### PR TITLE
Inventory Cargo dependencies of Rust projects (close #32)

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,6 +22,10 @@
   name = "github.com/mholt/archiver"
   version = "2.0.0"
 
+[[constraint]]
+  name = "github.com/BurntSushi/toml"
+  version = "0.3.1"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module licensezero.com/cli
 go 1.12
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/badoux/checkmail v0.0.0-20180430153108-0755fe2dc241
 	github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76
 	github.com/licensezero/cli v6.1.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/badoux/checkmail v0.0.0-20180430153108-0755fe2dc241 h1:lHeC0f6yPy5kFeO/EKD8TUgE6G6PLlyqVAYQ6GMh+5I=
 github.com/badoux/checkmail v0.0.0-20180430153108-0755fe2dc241/go.mod h1:r5ZalvRl3tXevRNJkwIB6DC4DD3DMjIlY9NEU1XGoaQ=
 github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76 h1:eX+pdPPlD279OWgdx7f6KqIRSONuK7egk+jDx7OM3Ac=

--- a/inventory/cargo.go
+++ b/inventory/cargo.go
@@ -31,13 +31,13 @@ func readCargoCrates(packagePath string) ([]Project, error) {
 	return returned, nil
 }
 
-type cargoLicenseZeroMap struct {
+type CargoLicenseZeroMap struct {
 	Version   string                    `json:"version"`
 	Envelopes []ProjectManifestEnvelope `json:"ids"`
 }
 
 type cargoMetadataMap struct {
-	LicenseZero cargoLicenseZeroMap `json:"licensezero"`
+	LicenseZero CargoLicenseZeroMap `json:"licensezero"`
 }
 
 type cargoMetadataPackage struct {

--- a/inventory/cargo.go
+++ b/inventory/cargo.go
@@ -1,0 +1,69 @@
+package inventory
+
+import "encoding/json"
+import "os/exec"
+import "bytes"
+import "path"
+
+func readCargoCrates(packagePath string) ([]Project, error) {
+	var returned []Project
+	metadata, err := cargoReadMetadata(packagePath)
+	if err != nil {
+		return nil, err
+	}
+	for _, packageRecord := range metadata.Packages {
+		metadata := packageRecord.Metadata.LicenseZero
+		for _, envelope := range metadata.Envelopes {
+			projectID := envelope.Manifest.ProjectID
+			if alreadyHaveProject(returned, projectID) {
+				continue
+			}
+			project := Project{
+				Type:     "cargo",
+				Path:     path.Dir(packageRecord.ManifestPath),
+				Name:     packageRecord.Name,
+				Version:  packageRecord.Version,
+				Envelope: envelope,
+			}
+			returned = append(returned, project)
+		}
+	}
+	return returned, nil
+}
+
+type cargoLicenseZeroMap struct {
+	Version   string                    `json:"version"`
+	Envelopes []ProjectManifestEnvelope `json:"ids"`
+}
+
+type cargoMetadataMap struct {
+	LicenseZero cargoLicenseZeroMap `json:"licensezero"`
+}
+
+type cargoMetadataPackage struct {
+	Name         string           `json:"name"`
+	Version      string           `json:"version"`
+	ManifestPath string           `json:"manifest_path"`
+	Metadata     cargoMetadataMap `json:"metadata"`
+}
+
+type cargoMetadataOutput struct {
+	Packages []cargoMetadataPackage `json:"packages"`
+}
+
+func cargoReadMetadata(packagePath string) (*cargoMetadataOutput, error) {
+	list := exec.Command("cargo", "metadata", "--format-version", "1")
+	list.Dir = packagePath
+	var stdout bytes.Buffer
+	list.Stdout = &stdout
+	err := list.Run()
+	if err != nil {
+		return nil, err
+	}
+	var parsed cargoMetadataOutput
+	json.Unmarshal(stdout.Bytes(), &parsed)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -140,6 +140,7 @@ func readProjects(cwd string) ([]Project, error) {
 		readNPMProjects,
 		readRubyGemsProjects,
 		readGoDeps,
+		readCargoCrates,
 		recurseLicenseZeroFiles,
 	}
 	returned := []Project{}

--- a/subcommands/license.go
+++ b/subcommands/license.go
@@ -177,7 +177,7 @@ func writeCargoTOML(read []byte, cargoTOML string, response *api.PublicResponse,
 	}
 	packageRecord, hasPackage := parsed["package"].(map[string]interface{})
 	if !hasPackage {
-		Fail("Cago.toml does not have \"package\" data.")
+		Fail("Cargo.toml does not have \"package\" data.")
 	}
 	metadata, hasMetadata := packageRecord["metadata"].(map[string]interface{})
 	if !hasMetadata {


### PR DESCRIPTION
This PR implements first-class support for Cargo crate dependencies of Rust projects. The approach is twofold:

1.  Expect License Zero crates to include signed metadata in `package.metadata.licensezero` of `Cargo.toml`.

2.  Run `cargo metadata` for metadata for all project dependencies.

Special thanks to @zkat, @ashleygwilliams, and @mgattozzi.